### PR TITLE
Fix: Include templates and static files in distribution (#53)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,8 @@ include requirements.txt
 recursive-include axion_hdl *.py *.md
 recursive-include instructions *.md
 recursive-include tests *.py *.vhd *.c *.sh
+recursive-include axion_hdl/templates *
+recursive-include axion_hdl/static *
 exclude *.pyc
 exclude __pycache__
 prune .git


### PR DESCRIPTION
This PR fixes issue #53 by updating  to include the  and  directories, which are required for the GUI to function properly in packaged distributions.