### PR TITLE
docs: fix PyPI documentation URL to point to docs directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ docs = [
 
 [project.urls]
 Homepage = "https://github.com/bugratufan/axion-hdl"
-Documentation = "https://github.com/bugratufan/axion-hdl#readme"
+Documentation = "https://github.com/bugratufan/axion-hdl/tree/main/docs"
 Repository = "https://github.com/bugratufan/axion-hdl"
 "Bug Tracker" = "https://github.com/bugratufan/axion-hdl/issues"
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url='https://github.com/bugratufan/axion-hdl',
     project_urls={
         'Bug Tracker': 'https://github.com/bugratufan/axion-hdl/issues',
-        'Documentation': 'https://github.com/bugratufan/axion-hdl#readme',
+        'Documentation': 'https://github.com/bugratufan/axion-hdl/tree/main/docs',
         'Source Code': 'https://github.com/bugratufan/axion-hdl',
     },
     packages=find_packages(exclude=['tests', 'tests.*', 'examples', 'output', 'waveforms', 'work']),


### PR DESCRIPTION
## Summary
When clicking 'Documentation' on PyPI, it was redirecting to the GitHub README. This PR updates the URL to point to the /docs directory instead.

## Changes
- `pyproject.toml`: Updated Documentation URL
- `setup.py`: Updated Documentation URL