### PR TITLE
sync: main → develop (CI fix)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,50 +1,26 @@
 # Publish to PyPI Workflow
-# Automatically publishes to PyPI when code is pushed to main branch
+# Automatically publishes to PyPI when the Tests workflow passes on main branch
 # Also creates a GitHub release with the version tag
 
 name: Publish to PyPI
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Tests"]
     branches: [main]
+    types: [completed]
   workflow_dispatch:  # Manual trigger
 
 jobs:
-  # First, run tests to ensure everything passes
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      
-      - name: Install GHDL
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ghdl
-      
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
-          pip install pytest pytest-cov
-      
-      - name: Run tests
-        run: make test
-
-  # Build the package
+  # Build the package (only if tests passed, or manual trigger)
   build:
-    needs: test
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -79,6 +55,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       
       - name: Get version
         id: version


### PR DESCRIPTION
## Summary
- Sync main branch changes back to develop
- Removes redundant test job from publish workflow (publish now triggers on Tests workflow completion instead of running its own tests)

## Changes
- `fix(ci): remove redundant test job from publish workflow`