### PR TITLE
feat(gui): add beta warning popup on session start

### DIFF
--- a/axion_hdl/templates/base.html
+++ b/axion_hdl/templates/base.html
@@ -176,7 +176,7 @@
     <script>
         (function () {
             var STORAGE_KEY = 'axion_hdl_beta_warning_seen';
-            if (!localStorage.getItem(STORAGE_KEY)) {
+            if (!sessionStorage.getItem(STORAGE_KEY)) {
                 document.addEventListener('DOMContentLoaded', function () {
                     var modal = new bootstrap.Modal(document.getElementById('betaWarningModal'), {
                         backdrop: 'static',
@@ -184,7 +184,7 @@
                     });
                     modal.show();
                     document.getElementById('betaWarningModal').addEventListener('hidden.bs.modal', function () {
-                        localStorage.setItem(STORAGE_KEY, '1');
+                        sessionStorage.setItem(STORAGE_KEY, '1');
                     });
                 });
             }

--- a/axion_hdl/templates/base.html
+++ b/axion_hdl/templates/base.html
@@ -131,22 +131,22 @@
                     <div class="d-flex align-items-center gap-2">
                         <i class="bi bi-exclamation-triangle-fill" style="color: #ffc107; font-size: 1.3rem;"></i>
                         <h5 class="modal-title mb-0" id="betaWarningModalLabel" style="color: #ffc107;">
-                            GUI Beta Sürümü
+                            GUI Beta Notice
                         </h5>
                     </div>
                 </div>
                 <div class="modal-body" style="color: var(--text-primary, #cdd6f4);">
                     <p>
-                        Axion-HDL'nin grafik arayüzü (GUI) şu anda <strong style="color: #ffc107;">beta aşamasındadır</strong>.
-                        Kullanım sırasında beklenmedik hatalar veya desteklenmeyen özellikler ile karşılaşabilirsiniz.
+                        The Axion-HDL graphical interface is currently in <strong style="color: #ffc107;">beta</strong>.
+                        You may encounter unexpected errors or features that are not yet fully supported.
                     </p>
                     <p>
-                        Stabil ve tam özellikli kullanım için <strong>CLI arayüzünü</strong> tercih etmenizi öneririz.
+                        For stable and fully-featured usage, the <strong>CLI interface</strong> is recommended.
                     </p>
                     <div style="background: rgba(255, 193, 7, 0.08); border-left: 3px solid #ffc107; padding: 0.75rem 1rem; border-radius: 0 4px 4px 0; margin-top: 0.5rem;">
                         <p class="mb-1" style="font-size: 0.9rem;">
                             <i class="bi bi-bug me-1"></i>
-                            Bir hata ile karşılaşırsanız GitHub üzerinden issue açarak bildirmenizi rica ederiz:
+                            If you run into a bug, please report it by opening an issue on GitHub:
                         </p>
                         <a href="https://github.com/bugratufan/axion-hdl/issues/new" target="_blank" rel="noopener"
                             style="color: #ffc107; font-size: 0.9rem; word-break: break-all;">
@@ -157,7 +157,7 @@
                 </div>
                 <div class="modal-footer" style="border-top: 1px solid rgba(255, 193, 7, 0.2);">
                     <button type="button" class="btn btn-warning btn-sm px-4" data-bs-dismiss="modal">
-                        Anladım, Devam Et
+                        Got it, Continue
                     </button>
                 </div>
             </div>

--- a/axion_hdl/templates/base.html
+++ b/axion_hdl/templates/base.html
@@ -144,14 +144,15 @@
                         For stable and fully-featured usage, the <strong>CLI interface</strong> is recommended.
                     </p>
                     <div style="background: rgba(255, 193, 7, 0.08); border-left: 3px solid #ffc107; padding: 0.75rem 1rem; border-radius: 0 4px 4px 0; margin-top: 0.5rem;">
-                        <p class="mb-1" style="font-size: 0.9rem;">
+                        <p class="mb-2" style="font-size: 0.9rem;">
                             <i class="bi bi-bug me-1"></i>
-                            If you run into a bug, please report it by opening an issue on GitHub:
+                            If you run into a bug, please report it on GitHub:
                         </p>
-                        <a href="https://github.com/bugratufan/axion-hdl/issues/new" target="_blank" rel="noopener"
-                            style="color: #ffc107; font-size: 0.9rem; word-break: break-all;">
+                        <a href="https://github.com/bugratufan/axion-hdl/issues/new?template=bug_report.md"
+                            target="_blank" rel="noopener" class="btn btn-sm"
+                            style="background: rgba(255,193,7,0.15); border: 1px solid rgba(255,193,7,0.5); color: #ffc107;">
                             <i class="bi bi-github me-1"></i>
-                            github.com/bugratufan/axion-hdl/issues/new
+                            Open a Bug Report
                         </a>
                     </div>
                 </div>

--- a/axion_hdl/templates/base.html
+++ b/axion_hdl/templates/base.html
@@ -141,7 +141,7 @@
                         You may encounter unexpected errors or features that are not yet fully supported.
                     </p>
                     <p>
-                        For stable and fully-featured usage, the <strong>CLI interface</strong> is recommended.
+                        For stable and fully-featured usage, the <strong>CLI interface</strong> or <strong>Python API</strong> is recommended.
                     </p>
                     <div style="background: rgba(255, 193, 7, 0.08); border-left: 3px solid #ffc107; padding: 0.75rem 1rem; border-radius: 0 4px 4px 0; margin-top: 0.5rem;">
                         <p class="mb-2" style="font-size: 0.9rem;">

--- a/axion_hdl/templates/base.html
+++ b/axion_hdl/templates/base.html
@@ -122,6 +122,48 @@
         </div>
     </footer>
 
+    <!-- Beta Warning Modal -->
+    <div class="modal fade" id="betaWarningModal" tabindex="-1" aria-labelledby="betaWarningModalLabel"
+        aria-modal="true" role="dialog">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content" style="border: 1px solid rgba(255, 193, 7, 0.4); background: var(--bg-secondary, #1e1e2e);">
+                <div class="modal-header" style="border-bottom: 1px solid rgba(255, 193, 7, 0.2);">
+                    <div class="d-flex align-items-center gap-2">
+                        <i class="bi bi-exclamation-triangle-fill" style="color: #ffc107; font-size: 1.3rem;"></i>
+                        <h5 class="modal-title mb-0" id="betaWarningModalLabel" style="color: #ffc107;">
+                            GUI Beta Sürümü
+                        </h5>
+                    </div>
+                </div>
+                <div class="modal-body" style="color: var(--text-primary, #cdd6f4);">
+                    <p>
+                        Axion-HDL'nin grafik arayüzü (GUI) şu anda <strong style="color: #ffc107;">beta aşamasındadır</strong>.
+                        Kullanım sırasında beklenmedik hatalar veya desteklenmeyen özellikler ile karşılaşabilirsiniz.
+                    </p>
+                    <p>
+                        Stabil ve tam özellikli kullanım için <strong>CLI arayüzünü</strong> tercih etmenizi öneririz.
+                    </p>
+                    <div style="background: rgba(255, 193, 7, 0.08); border-left: 3px solid #ffc107; padding: 0.75rem 1rem; border-radius: 0 4px 4px 0; margin-top: 0.5rem;">
+                        <p class="mb-1" style="font-size: 0.9rem;">
+                            <i class="bi bi-bug me-1"></i>
+                            Bir hata ile karşılaşırsanız GitHub üzerinden issue açarak bildirmenizi rica ederiz:
+                        </p>
+                        <a href="https://github.com/bugratufan/axion-hdl/issues/new" target="_blank" rel="noopener"
+                            style="color: #ffc107; font-size: 0.9rem; word-break: break-all;">
+                            <i class="bi bi-github me-1"></i>
+                            github.com/bugratufan/axion-hdl/issues/new
+                        </a>
+                    </div>
+                </div>
+                <div class="modal-footer" style="border-top: 1px solid rgba(255, 193, 7, 0.2);">
+                    <button type="button" class="btn btn-warning btn-sm px-4" data-bs-dismiss="modal">
+                        Anladım, Devam Et
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Bootstrap 5 JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 
@@ -130,6 +172,24 @@
 
     <!-- GUI Common Scripts -->
     <script src="{{ url_for('static', filename='js/gui.js') }}"></script>
+
+    <script>
+        (function () {
+            var STORAGE_KEY = 'axion_hdl_beta_warning_seen';
+            if (!localStorage.getItem(STORAGE_KEY)) {
+                document.addEventListener('DOMContentLoaded', function () {
+                    var modal = new bootstrap.Modal(document.getElementById('betaWarningModal'), {
+                        backdrop: 'static',
+                        keyboard: false
+                    });
+                    modal.show();
+                    document.getElementById('betaWarningModal').addEventListener('hidden.bs.modal', function () {
+                        localStorage.setItem(STORAGE_KEY, '1');
+                    });
+                });
+            }
+        })();
+    </script>
 
     {% block scripts %}{% endblock %}
 </body>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,6 +152,8 @@ def browser_context_args(browser_context_args):
 @pytest.fixture
 def gui_page(page, gui_server):
     """Fixture that provides a page connected to the GUI server"""
+    # Suppress the beta warning modal before any page script runs
+    page.add_init_script("sessionStorage.setItem('axion_hdl_beta_warning_seen', '1')")
     page.goto(gui_server.url)
     page.wait_for_load_state("networkidle")
     return page


### PR DESCRIPTION
## Summary

- Adds a Bootstrap modal to `base.html` that warns users the GUI is in **beta** on every new browser session
- Recommends the CLI interface or Python API as stable alternatives
- Includes an **Open a Bug Report** button linking directly to the `bug_report.md` issue template on GitHub

## Behaviour

- Popup appears on every new session (tab/window open)
- Dismissed once per session via `sessionStorage` — navigating between pages does not re-trigger it
- Modal is `backdrop: static` with keyboard dismiss disabled, requiring the user to click **Got it, Continue**

## Test plan

- [ ] Launch GUI (`axion-hdl --gui`), verify popup appears on first page load
- [ ] Click **Got it, Continue**, navigate to another page — popup should not reappear
- [ ] Close the tab and reopen the GUI — popup should appear again
- [ ] Click **Open a Bug Report** — should open `https://github.com/bugratufan/axion-hdl/issues/new?template=bug_report.md` in a new tab