### PR TITLE
fix: CLI help on no args, readthedocs URL, and About button link

### DIFF
--- a/axion_hdl/cli.py
+++ b/axion_hdl/cli.py
@@ -20,7 +20,7 @@ Exit Codes:
     0 - Success
     1 - Error (invalid arguments, analysis failure, or generation failure)
 
-For more information, visit: https://github.com/bugratufan/axion-hdl
+For more information, visit: https://axion-hdl.readthedocs.io
 """
 
 import argparse
@@ -58,7 +58,7 @@ Examples:
   axion-hdl -s ./hdl -o ./out --vhdl --c-header
   axion-hdl -s ./design --doc-format html
 
-For more information, visit: https://github.com/bugratufan/axion-hdl
+For more information, visit: https://axion-hdl.readthedocs.io
         """
     )
     
@@ -236,6 +236,11 @@ For more information, visit: https://github.com/bugratufan/axion-hdl
         help='Run GUI in debug mode (enables hot-reloading)'
     )
     
+    # Show help when called with no arguments
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(0)
+
     # Parse arguments
     args = parser.parse_args()
 

--- a/axion_hdl/cli.py
+++ b/axion_hdl/cli.py
@@ -236,8 +236,8 @@ For more information, visit: https://axion-hdl.readthedocs.io
         help='Run GUI in debug mode (enables hot-reloading)'
     )
     
-    # Show help when called with no arguments
-    if len(sys.argv) == 1:
+    # Show help when called with no arguments and no fallback config exists
+    if len(sys.argv) == 1 and not os.path.exists(".axion_conf"):
         parser.print_help()
         sys.exit(0)
 

--- a/axion_hdl/doc_generators.py
+++ b/axion_hdl/doc_generators.py
@@ -283,7 +283,15 @@ class DocGenerator:
 
         # Exclude canonical entries (present only for register-space generation, not docs)
         visible = [m for m in modules if not m.get('_hide_from_docs')]
-        visible.sort(key=lambda m: m.get('base_address', 0))
+        def _base_addr_int(m):
+            v = m.get('base_address', 0)
+            if v is None:
+                return 0
+            try:
+                return int(v, 0) if isinstance(v, str) else int(v)
+            except (ValueError, TypeError):
+                return 0
+        visible.sort(key=_base_addr_int)
 
         # Create index page in ROOT output dir
         index_path = os.path.join(self.output_dir, "index.html")
@@ -345,7 +353,7 @@ class DocGenerator:
         
         content = f'''
 <div class="top-nav">
-    <a href="https://axion-hdl.com" class="about-link" target="_blank" rel="noopener">About Axion-HDL</a>
+    <a href="https://axion-hdl.com" class="about-link" target="_blank" rel="noopener noreferrer">About Axion-HDL</a>
 </div>
 <div class="hero">
     <div class="hero-logo">

--- a/axion_hdl/doc_generators.py
+++ b/axion_hdl/doc_generators.py
@@ -283,6 +283,7 @@ class DocGenerator:
 
         # Exclude canonical entries (present only for register-space generation, not docs)
         visible = [m for m in modules if not m.get('_hide_from_docs')]
+        visible.sort(key=lambda m: m.get('base_address', 0))
 
         # Create index page in ROOT output dir
         index_path = os.path.join(self.output_dir, "index.html")
@@ -344,7 +345,7 @@ class DocGenerator:
         
         content = f'''
 <div class="top-nav">
-    <a href="html/about.html" class="about-link">About Axion-HDL</a>
+    <a href="https://axion-hdl.com" class="about-link" target="_blank" rel="noopener">About Axion-HDL</a>
 </div>
 <div class="hero">
     <div class="hero-logo">


### PR DESCRIPTION
## Summary

- `axion-hdl` called with no arguments now prints help and exits cleanly instead of defaulting to the current directory
- `For more information` URL in CLI help text updated from GitHub to `https://axion-hdl.readthedocs.io`
- **About Axion-HDL** button in generated `index.html` now links to `https://axion-hdl.com` (opens in new tab) instead of the local `html/about.html` page
- Modules in generated `index.html` are now sorted by base address in ascending order

## Test plan

- [ ] `axion-hdl` with no arguments prints help and exits with code 0
- [ ] `axion-hdl --help` epilog shows `https://axion-hdl.readthedocs.io`
- [ ] Generated `index.html` — About Axion-HDL button href is `https://axion-hdl.com`
- [ ] Generated `index.html` — modules listed in ascending base address order